### PR TITLE
Docker/README/setup.sh: ease setup on WSL2

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -43,6 +43,8 @@ ARG USER_UID=1000
 RUN useradd -m -u $USER_UID -s /bin/bash dev \
     && echo "dev ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+ENV USER=dev
+ENV HOME=/home/dev
 USER $USERNAME
 
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc \

--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ This codebase implements a visual geo-localization system for drones that matche
 - Follow the official installation guide: [Install Docker Engine](https://docs.docker.com/engine/install/).
 - Apply the Linux post-installation configuration as non-root user: [Linux post-installation steps for Docker Engine](https://docs.docker.com/engine/install/linux-postinstall/).
 
-**Step 2: NVIDIA Container Toolkit (optional)**
+If you are running WSL2 on Windows:
+
+- Install [Docker Desktop for Windows](https://docs.docker.com/desktop/setup/install/windows-install/) (not Docker Engine inside WSL).
+- In Docker Desktop, select **Settings, Resources, WSL Integration** and enable your distro.
+- Verify Docker works by running, `docker run hello-world`
+
+**Step 2: NVIDIA Container Toolkit (optional, WSL2 users should skip this step)**
 
 > If NVIDIA GPU is present.
 - Install the toolkit: [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,21 @@ sudo -v
 
 set -e
 
+# Require USER to be set (needed by ArduPilot prereqs script for usermod)
+if [[ -z "$USER" ]]; then
+    echo "ERROR: USER environment variable is not set."
+    echo "Run setup as: USER=dev bash setup.sh"
+    exit 1
+fi
+
+# Validate expected workspace layout
+if [[ ! -d ~/ngps_ws/src/ngps_flight ]]; then
+    echo "ERROR: ~/ngps_ws/src/ngps_flight not found."
+    echo "Clone the repo there or create a symlink:"
+    echo "  ln -s /path/to/ngps_flight ~/ngps_ws/src/ngps_flight"
+    exit 1
+fi
+
 echo "Setting up ngps_ws :)"
 cd ~/ngps_ws
 


### PR DESCRIPTION
This eases the setup on WSL2 by doing the following:

1. Dockerfile ensures USER env variable is set (it seems it may not be set on WSL2 machines)
2. setup.sh checks that USER env variable is set and that this ngps_flight repo is in the expected directory
3. README gets a few lines helping the WSL2 setup